### PR TITLE
let KOMA document class handle parskip when applicable

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -159,12 +159,13 @@ $endif$
 }{}
 $if(indent)$
 $else$
-\IfFileExists{parskip.sty}{%
-\usepackage{parskip}
-}{% else
-\setlength{\parindent}{0pt}
-\setlength{\parskip}{6pt plus 2pt minus 1pt}
-}
+\@ifundefined{KOMAClassName}{%
+  \IfFileExists{parskip.sty}{%
+  \usepackage{parskip}
+  }{% else
+  \setlength{\parindent}{0pt}
+  \setlength{\parskip}{6pt plus 2pt minus 1pt}
+  }}{\KOMAoptions{parskip=half}}
 $endif$
 $if(verbatim-in-note)$
 \usepackage{fancyvrb}


### PR DESCRIPTION
As discussed in jgm/pandoc#5131 (comment) it is better to let KOMA document classes handle parskip itself.

Please check the indentation of the added code, which might not be the style that should be adhered to.